### PR TITLE
ACNA-344 - Migrate aio-cli-config to aio-cna-core-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,31 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 -->
 
-aio-cli-config
+aio-cna-core-config
 =======================
 
-[![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
-[![Version](https://img.shields.io/npm/v/@adobe/aio-cli-config.svg)](https://npmjs.org/package/@adobe/aio-cli-config)
-[![Downloads/week](https://img.shields.io/npm/dw/@adobe/aio-cli-config.svg)](https://npmjs.org/package/@adobe/aio-cli-config)
-[![Build Status](https://travis-ci.com/adobe/aio-cli-config.svg?branch=master)](https://travis-ci.com/adobe/aio-cli-config)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Greenkeeper badge](https://badges.greenkeeper.io/adobe/aio-cli-plugin-pgb.svg)](https://greenkeeper.io/)
-[![Codecov Coverage](https://img.shields.io/codecov/c/github/adobe/aio-cli-config/master.svg?style=flat-square)](https://codecov.io/gh/adobe/aio-cli-config/)
+[![Version](https://img.shields.io/npm/v/@adobe/aio-cna-core-config.svg)](https://npmjs.org/package/@adobe/aio-cna-core-config)
+[![Downloads/week](https://img.shields.io/npm/dw/@adobe/aio-cna-core-config.svg)](https://npmjs.org/package/@adobe/aio-cna-core-config)
+[![Build Status](https://travis-ci.com/adobe/aio-cna-core-config.svg?branch=master)](https://travis-ci.com/adobe/aio-cna-core-config)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Greenkeeper badge](https://badges.greenkeeper.io/adobe/aio-cna-core-config.svg)](https://greenkeeper.io/)
+[![Codecov Coverage](https://img.shields.io/codecov/c/github/adobe/aio-cna-core-config/master.svg?style=flat-square)](https://codecov.io/gh/adobe/aio-cna-core-config/)
 
-This is a nodejs module to allow management of persistant and environment variable configuration by aio-cli plugins.
+This is a nodejs module to allow management of persistant and environment variable configuration.
 
 The module can be added to your project with:
 
 ```javascript
-> yarn add aio-cli-config
+> yarn add aio-cna-core-config
 
 or
 
-> npm install aio-cli-config --save
+> npm install aio-cna-core-config --save
 ```
 
 Here is a snippet:
 
 ```javascript
-const config = require('aio-cli-config')
+const config = require('aio-cna-core-config')
 
 // set a key value
 config.set('pgb.authtoken', 1234)

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@adobe/aio-cli-config",
+  "name": "@adobe/aio-cna-core-config",
   "version": "1.0.12",
-  "description": "Adobe I/O configuration module for the AIO CLI",
+  "description": "Adobe I/O Configuration Module",
   "main": "./src",
-  "repository": "https://github.com/adobe/aio-cli-config",
-  "author": "rudd@adobe.com",
+  "repository": "https://github.com/adobe/aio-cna-core-config",
+  "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=8.10.0"


### PR DESCRIPTION
New Repo:
- [X] clone the old repo into a new repo
- [X] rename the npm package to the new name
- [x] Update README.md badges
- [x] make sure Travis CI works
- [x] make sure Codecov works
- ~[ ] publish from the new repo~ see #2 
- ~[ ] Update [aio-cli-health](https://github.com/adobe/aio-cli-health) status page~ see https://github.com/adobe/aio-cli-health/issues/5

Old Repo:
- [x] add a README link to the new repo
- [x] archive the old repo
- ~[ ] npm deprecate the old module pointing to the new~ see #3

Update dependencies to point to new module:
- ~[ ] aio-cli-plugin-config~ see https://github.com/adobe/aio-cli-plugin-config/issues/53
- ~[ ] aio-cli-plugin-console~ see https://github.com/adobe/aio-cli-plugin-console/issues/51
- ~[ ] aio-cli-plugin-jwt-auth~ see https://github.com/adobe/aio-cli-plugin-jwt-auth/issues/42
- ~[ ] aio-cli-plugin-runtime~ see https://github.com/adobe/aio-cli-plugin-runtime/issues/35
- ???